### PR TITLE
Add Kotlin DSL usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,18 @@ or if you want to use more stable version:
  
 `implementation 'com.github.barteksc:android-pdf-viewer:2.8.2'`
 
+For Gradle Kotlin DSL:
+
+```kotlin
+implementation("com.github.barteksc:android-pdf-viewer:3.2.0-beta.1")
+```
+
+or if you want to use more stable version:
+
+```kotlin
+implementation("com.github.barteksc:android-pdf-viewer:2.8.2")
+```
+
 Library is available in jcenter repository, probably it'll be in Maven Central soon.
 
 ## ProGuard


### PR DESCRIPTION
## Summary
- document how to depend on this library when using Gradle Kotlin DSL

## Testing
- `./gradlew test` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_6868ca4d9a748322862aece4f51f0b5a