### PR TITLE
Remove unused Bintray plugin

### DIFF
--- a/android-pdf-viewer/build.gradle
+++ b/android-pdf-viewer/build.gradle
@@ -42,4 +42,6 @@ dependencies {
     api 'com.github.barteksc:pdfium-android:1.9.0'
 }
 
-apply from: 'bintray.gradle'
+// The publishing script depends on the Bintray plugin which is no longer
+// available. Comment out to prevent build errors when resolving the plugin.
+// apply from: 'bintray.gradle'

--- a/build.gradle
+++ b/build.gradle
@@ -6,8 +6,11 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:7.4.2'
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
-        classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
+        // The following plugins were previously used for publishing the library
+        // but rely on the now defunct Bintray repository. They are commented out
+        // to avoid build failures due to missing artifacts.
+        // classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
+        // classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
     }
 }
 


### PR DESCRIPTION
## Summary
- comment out Bintray publishing plugin in `build.gradle`
- disable Bintray publishing script in library build file

Gradle failed to find the Bintray plugin because the repository is no longer
available. The build now avoids loading that plugin.

## Testing
- `./gradlew --version`
- `./gradlew --offline :sample:assembleDebug` *(fails: No cached version of com.android.tools.build:gradle:7.4.2 available for offline mode)*

------
https://chatgpt.com/codex/tasks/task_e_686b46261f5083229b2cfb19a6b31572