### PR TITLE
Enable AndroidX

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,25 @@ implementation("com.github.barteksc:android-pdf-viewer:2.8.2")
 
 Library is available in jcenter repository, probably it'll be in Maven Central soon.
 
+## Building the sample offline
+
+Gradle 7.6 and the Android Gradle plugin 7.4.2 require JDK 11–17. Before
+building on a machine without network access, fetch all dependencies on an
+online machine:
+
+```bash
+./gradlew :sample:assembleDebug
+```
+
+Copy the project directory and your `~/.gradle` cache to the offline computer,
+ensure the Android SDK is installed, and run:
+
+```bash
+./gradlew --offline :sample:assembleDebug
+```
+
+The resulting APK will be in `sample/build/outputs/apk/debug/`.
+
 ## ProGuard
 If you are using ProGuard, add following rule to proguard config file:
 

--- a/android-pdf-viewer/build.gradle
+++ b/android-pdf-viewer/build.gradle
@@ -42,4 +42,7 @@ dependencies {
     api 'com.github.barteksc:pdfium-android:1.9.0'
 }
 
-apply from: 'bintray.gradle'
+// The publishing script depends on the Bintray plugin which is no longer
+// available. Comment out to prevent build errors when resolving the plugin.
+// apply from: 'bintray.gradle'
+

--- a/build.gradle
+++ b/build.gradle
@@ -6,8 +6,11 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:7.4.2'
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
-        classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
+        // The following plugins were previously used for publishing the library
+        // but rely on the now defunct Bintray repository. They are commented out
+        // to avoid build failures due to missing artifacts.
+        // classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
+        // classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+android.useAndroidX=true


### PR DESCRIPTION
## Summary
- set `android.useAndroidX=true` so Gradle resolves AndroidX artifacts
- comment out Bintray plugin usage so outdated plugins don't break builds
- document how to build the sample offline and the required JDK

## Testing
- `./gradlew --version`
- `./gradlew :sample:assembleDebug` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_686b46261f5083229b2cfb19a6b31572